### PR TITLE
Make "npm start" work

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "subdomain": "wtfjs",
   "scripts": {
-    "start": "server.js"
+    "start": "node ./server.js"
   },
   "domains": [
     "wtfjs.com",


### PR DESCRIPTION
I suspect the original might have worked on Windows (?) but it
certainly didn't work on Linux.
