### PR TITLE
Update to match newer express API

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,5 @@
 var express = require('express')
-,   app     = express.createServer()
+,   app     = express()
 ,   path    = require('path')
 ,   engine  = require('ejs-locals')
 


### PR DESCRIPTION
This gets rid of the following deprecation warning:

  Warning: express.createServer() is deprecated, express
  applications no longer inherit from http.Server,
  please use:

```
var express = require("express");
var app = express();
```
