### PR TITLE
Fix RSS feed (fixes #33)

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -54,7 +54,7 @@ Post.rss = function () {
         s += '<description>' + htmlesc(posts[i].html()) + '</description>';
         s += '<link>' + htmlesc(domain + posts[i].url()) + '</link>';
         s += '<guid>' + htmlesc(domain + posts[i].url()) + '</guid>';
-        s += '<pubDate>' + htmlesc(posts[i].created()) + '</pubDate>';
+        s += '<pubDate>' + htmlesc(posts[i].created().toUTCString()) + '</pubDate>';
         s += '</item>';
     }
     s += '</channel></rss>';

--- a/server.js
+++ b/server.js
@@ -28,7 +28,8 @@ app.get("/:y/:m/:d/:title", function(req, res) {
 
 // GET "/rss"
 app.get("/rss", function(req, res) {
-    res.headers['Content-Type'] = 'text/xml; charset=utf-8'
+    res.type('text/xml')
+    res.charset = 'utf-8'
     res.send(Post.rss())
 })
 


### PR DESCRIPTION
The header-setting code needs to change to work with newer versions
of Express.

I'm not sure why the creation date in the article-processing code
ever worked because "new Date()" returns an object, not a string.
