### PR TITLE
Fix jquery.js and app.js links in views/layout.ejs

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -25,8 +25,8 @@
             <div id="foot">wtfjs is <a href="/license">free software</a>. get the <a href="http://github.com/brianleroux/wtfjs">source on github</a>. </div>
         </div>
         <a href="http://github.com/brianleroux/wtfjs"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub" /></a>
-        <script src="/public/jquery-1.4.2.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="/public/app.js" type="text/javascript" charset="utf-8"></script>
+        <script src="/jquery-1.4.2.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="/app.js" type="text/javascript" charset="utf-8"></script>
         <script type="text/javascript" charset="utf-8">
             var _gaq = _gaq || [];
              _gaq.push(['_setAccount', 'UA-190386-6']);


### PR DESCRIPTION
Locations of both "/public/jquery-1.4.2.min.js" and "/public/app.js" are invalid, as both files are on the root.

Fixes the 404 not found errors in the development console.
