### PR TITLE
Slight correction about why an unbound name on left hand side of a for-in header ends up on the global

### DIFF
--- a/posts/2011-07-26-iteration-demoralization.md
+++ b/posts/2011-07-26-iteration-demoralization.md
@@ -26,25 +26,14 @@ What you might not have guessed, is what this will output:
     console.log(window.name);
 </code>
 
-its:
+it's:
 
 > "2"
 
 
-Iteration is assignment, and without the use of the `var` keyword, you're really using the `this` object - which in the context of a raw function declaration is the `window` object.
+Iteration is assignment, and without the use of the `var` keyword, you're really using the global object - which in this context is the `window` object.
 
 So the original function is equivalent to:
-
-<code>
-    function allNames() {
-      var names = [ 'dan', 'anthony', 'pavel' ];
-      for (this.name in names) {
-        console.log(name);
-      }
-    }
-</code>
-
-Which is also equivalent to:
 
 <code>
     function allNames() {


### PR DESCRIPTION
While reading through your blog, I noticed a small error in why in `for (name in ...) ...` `name` ends up on the global: unbound assignment ignores the this object entirely and instead looks up the static scope chain (including with objects) looking for a scope with the name on it. In the case that no such scope is found, a new property is created on the global object and is used. You can test this by passing a different `this` object to `allNames` (e.g. using `.call({})`) and observing that the behavior is the same.

I'm not sure what your policy for editing old posts is, but I figured you might be interested anyway.
