### PR TITLE
false == 'false' // false

### DIFF
--- a/posts/2013-03-6-false-isnt-false.md
+++ b/posts/2013-03-6-false-isnt-false.md
@@ -1,0 +1,13 @@
+```
+    true == 'true'     // true
+    false == 'false';  // false
+```
+
+This is expected behaviour as == doesn't do value equality, 
+but rather it does numeric value equality[1], thus 'false' is truethy, thus equals 1
+
+
+— [@grnadav][2]
+
+[1]:http://es5.github.com/#x11.9.1
+[2]:https://twitter.com/grnadav


### PR DESCRIPTION
== is commonly regraded as 'value equality', where it is mostly true (considering references to objects\functions as values), it is a gotcha\wtf item on boolean values.
This is because == actually does numeric value comparison, causeing the expression:
false == 'false' to be evaluated to 0 (false) == 1 (the string 'false')
