### PR TITLE
Updated "magic function properties"

### DIFF
--- a/posts/2013-02-05-magic-function-properties.md
+++ b/posts/2013-02-05-magic-function-properties.md
@@ -14,7 +14,7 @@ Functions are objects, so you can set properties on them after creation.
 But not all the time.
 
 ```
-    var myFunction = function myFunction() { };
+    var f = function myFunction() { };
     f.name; // is 'myFunction'
 ```
 


### PR DESCRIPTION
The last example didn't actually work as `f` was still set either to the first example (`f = function() {}`), or it was assumed that `f` was supposed to be part of `myFunction`. In either case, it didn't work. Changed `var myFunction` to `f` which also makes it less confusing as to where `.name` gets it's name from.
