### PR TITLE
Fix example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It has never been easier to contribute a wtf to wtfjs.com!
 ### Example post format
 <pre>
 
-```
+``` javascript
     Array(20).map(function(elem) { return 'a'; }); // Array of undefined x 20
 ```
 
@@ -36,9 +36,6 @@ Thanks [Paul Irish](https://twitter.com/paul_irish) for the explanation.
 
 [1]:https://githubortwitter.com/yourusername
 </pre>
-
-Note that your code won't be highlighted :( If you'd like to figure out how to
-get '```' to highlight, please help and submit PR! Thank you! - @DTrejo
 
 the code
 ---


### PR DESCRIPTION
Tripple backticks does not automagically highights code snippets unless
format auto-guessing is used. Instead one should explicitly provide code
snippet format.

With that being said, this will not highlight:

```
console.log("nope");
```

And this will highlight snippet properly (depends on MD formatter though):

``` javascript
console.log("works");
```
