### PR TITLE
038 - 037 === 7

### DIFF
--- a/posts/2015-02-05-good-old-octal-decimal-wtf.md
+++ b/posts/2015-02-05-good-old-octal-decimal-wtf.md
@@ -1,0 +1,11 @@
+0-prefixed numbers are handled are automatically treated as octals. Or not.
+<code>
+  038 - 037 // 7 !?
+  037 // 31 thx to silent octal-to-decimal conversion
+  038 // 38 .. Silently switch to octal, silently fails to, and silently fallback to decimal
+</code>
+
+Instead of throwing a SyntaxError (8 & 9 should be invalid characters), octal mode silently switch to decimal if possible
+
+
+— [@nlesconnec](https://twitter.com/nlesconnec)


### PR DESCRIPTION
Tiny wtf involving prefixed numbers.
Auto conversion of 0-prefixed numbers to octal (and 0x to hexa) may be kinda weird, but js isn't to blame here.

It's becoming to get wtf when you use 0-prefixed numbers that cannot possibly be octals.
Instead of throwing a SyntaxError, any 0-number containing a 8 or 9 is handled as a good old decimal one.

```
> 038 - 037
7
```
