### PR TITLE
Fix encoding

### DIFF
--- a/src/html/get-wtfs-000wtfID/index.js
+++ b/src/html/get-wtfs-000wtfID/index.js
@@ -6,7 +6,7 @@ var arc = require('@architect/functions')
 var layout = require('@architect/shared/layout')
 
 function route(req, res) {
-  var filename = req.params.wtfID + '.md'
+  var filename = decodeURI(req.params.wtfID) + '.md'
   var filepath = path.join(__dirname, 'node_modules', '@architect', 'shared', 'md', filename)
   exists(filepath, function _exists(err, yasqueen) {
     if (err) {

--- a/src/html/get-wtfs/index.js
+++ b/src/html/get-wtfs/index.js
@@ -8,6 +8,7 @@ var files = fs.readdirSync(__dirname + '/node_modules/@architect/shared/md').fil
 function link(file) {
   var val = file.replace('.md', '')
   var name = val.replace(/-/g, ' ')
+  var name = encodeURI(name)
   return `<li><a href=/wtfs/${val}>${name}</a></li>`
 }
 

--- a/src/shared/md/2010-02-15-true-has-a-value.md
+++ b/src/shared/md/2010-02-15-true-has-a-value.md
@@ -1,10 +1,12 @@
 [@AtomFusion](http://twitter.com/AtomFusion) shows us that true sometimes has a value.
 
 ```
-    (true + 1) === 2;​ ​// true
+    (true + 1) === 2; // true
     (true + true) === 2; // true
     true === 2; // false
     true === 1; // false
 ```
 
 Wow wtf.
+
+*Explanation*: `true` is not actually `1`, but when you add `1` to it, `valueOf()` is called in order to cast it to a number so that JavaScript is able sum these two values which are now of the same type (double).

--- a/src/shared/md/2010-02-15-true-has-a-value.md
+++ b/src/shared/md/2010-02-15-true-has-a-value.md
@@ -9,4 +9,4 @@
 
 Wow wtf.
 
-*Explanation*: `true` is not actually `1`, but when you add `1` to it, `valueOf()` is called in order to cast it to a number so that JavaScript is able sum these two values which are now of the same type (double).
+**Explanation**: `true` is not actually `1`, but when you add `1` to it, `valueOf()` is called in order to cast it to a number so that JavaScript is able sum these two values which are now of the same type (double).


### PR DESCRIPTION
Fixes #152, fixes #147

@brianleroux
This page's status will be 404
https://wtfjs.com/wtfs/2013-12-15-charAt-is-not-the-same-as-[]

Manually encoding url
https://wtfjs.com/wtfs/2013-12-15-charAt-is-not-the-same-as-%5B%5D

avoids 404, but page cannot be found anyways.

**CAUTION:** Fix isn't checked yet!

# Fixes
- [ ] #152 
- [ ] #147